### PR TITLE
change layout back to be relative

### DIFF
--- a/src/algo.rs
+++ b/src/algo.rs
@@ -89,8 +89,7 @@ impl Forest {
             self.compute_internal(root, style.size.resolve(size), size, true, true)
         };
 
-        self.nodes[root].layout =
-            result::Layout { order: 0, size: result.size, location: Point::zero(), relative_location: Point::zero() };
+        self.nodes[root].layout = result::Layout { order: 0, size: result.size, location: Point::zero() };
 
         Self::round_layout(&mut self.nodes, &self.children, root, 0.0, 0.0);
     }
@@ -103,11 +102,11 @@ impl Forest {
         abs_y: f32,
     ) {
         let layout = &mut nodes[root].layout;
-        let abs_x = abs_x + layout.relative_location.x;
-        let abs_y = abs_y + layout.relative_location.y;
+        let abs_x = abs_x + layout.location.x;
+        let abs_y = abs_y + layout.location.y;
 
-        layout.location.x = sys::round(abs_x);
-        layout.location.y = sys::round(abs_y);
+        layout.location.x = sys::round(layout.location.x);
+        layout.location.y = sys::round(layout.location.y);
 
         layout.size.width = sys::round(abs_x + layout.size.width) - sys::round(abs_x);
         layout.size.height = sys::round(abs_y + layout.size.height) - sys::round(abs_y);
@@ -749,7 +748,6 @@ impl Forest {
                             order: self.children[node].iter().position(|n| *n == child.node).unwrap() as u32,
                             size: result.size,
                             location: Point::zero(),
-                            relative_location: Point::zero(),
                         },
                     );
                 }
@@ -1156,8 +1154,7 @@ impl Forest {
                     self.nodes[child.node].layout = result::Layout {
                         order: self.children[node].iter().position(|n| *n == child.node).unwrap() as u32,
                         size: result.size,
-                        location: Point::zero(),
-                        relative_location: Point {
+                        location: Point {
                             x: if is_row { offset_main } else { offset_cross },
                             y: if is_column { offset_main } else { offset_cross },
                         },
@@ -1306,18 +1303,16 @@ impl Forest {
                 self.nodes[child].layout = result::Layout {
                     order: order as u32,
                     size: result.size,
-                    relative_location: Point {
+                    location: Point {
                         x: if is_row { offset_main } else { offset_cross },
                         y: if is_column { offset_main } else { offset_cross },
                     },
-                    location: Point::zero(),
                 };
             }
         }
 
         fn hidden_layout(nodes: &mut [NodeData], children: &[sys::ChildrenVec<NodeId>], node: NodeId, order: u32) {
-            nodes[node].layout =
-                result::Layout { order, size: Size::zero(), location: Point::zero(), relative_location: Point::zero() };
+            nodes[node].layout = result::Layout { order, size: Size::zero(), location: Point::zero() };
 
             for (order, child) in children[node].iter().enumerate() {
                 hidden_layout(nodes, children, *child, order as _);

--- a/src/node.rs
+++ b/src/node.rs
@@ -206,6 +206,7 @@ impl Stretch {
         Ok(&self.forest.nodes[id].style)
     }
 
+    /// Return this node layout relative to its parent
     pub fn layout(&self, node: Node) -> Result<&Layout, Error> {
         let id = self.find_node(node)?;
         Ok(&self.forest.nodes[id].layout)

--- a/src/result.rs
+++ b/src/result.rs
@@ -8,12 +8,11 @@ pub struct Layout {
     pub(crate) order: u32,
     pub size: Size<f32>,
     pub location: Point<f32>,
-    pub(crate) relative_location: Point<f32>,
 }
 
 impl Layout {
     pub(crate) fn new() -> Self {
-        Self { order: 0, size: Size::zero(), location: Point::zero(), relative_location: Point::zero() }
+        Self { order: 0, size: Size::zero(), location: Point::zero() }
     }
 }
 

--- a/tests/simple_child.rs
+++ b/tests/simple_child.rs
@@ -1,0 +1,80 @@
+use stretch::{geometry::Point, style::Dimension};
+use stretch2 as stretch;
+
+#[test]
+fn simple_child() {
+    let mut stretch = stretch::Stretch::new();
+    let node0_0 = stretch
+        .new_node(
+            stretch::style::Style {
+                align_self: stretch::prelude::AlignSelf::Center,
+                size: stretch::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node0 = stretch
+        .new_node(
+            stretch::style::Style {
+                size: stretch::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
+                ..Default::default()
+            },
+            &[node0_0],
+        )
+        .unwrap();
+    let node1_0 = stretch
+        .new_node(
+            stretch::style::Style {
+                align_self: stretch::prelude::AlignSelf::Center,
+                size: stretch::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node1_1 = stretch
+        .new_node(
+            stretch::style::Style {
+                align_self: stretch::prelude::AlignSelf::Center,
+                size: stretch::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node1 = stretch
+        .new_node(
+            stretch::style::Style {
+                size: stretch::geometry::Size { width: Dimension::Undefined, height: Dimension::Undefined },
+                ..Default::default()
+            },
+            &[node1_0, node1_1],
+        )
+        .unwrap();
+    let node = stretch
+        .new_node(
+            stretch::style::Style {
+                size: stretch::geometry::Size { width: Dimension::Percent(100.0), height: Dimension::Percent(100.0) },
+                ..Default::default()
+            },
+            &[node0, node1],
+        )
+        .unwrap();
+    stretch
+        .compute_layout(
+            node,
+            stretch::geometry::Size {
+                width: stretch::prelude::Number::Defined(100f32),
+                height: stretch::prelude::Number::Defined(100f32),
+            },
+        )
+        .unwrap();
+    assert_eq!(stretch.layout(node).unwrap().location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(stretch.layout(node0).unwrap().location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(stretch.layout(node1).unwrap().location, Point { x: 10.0, y: 0.0 });
+    assert_eq!(stretch.layout(node0_0).unwrap().location, Point { x: 0.0, y: 0.0 });
+    // Layout is relative so node1_0 location starts at (0,0) and is not ofset by it's parent location
+    assert_eq!(stretch.layout(node1_0).unwrap().location, Point { x: 00.0, y: 0.0 });
+    assert_eq!(stretch.layout(node1_1).unwrap().location, Point { x: 10.0, y: 0.0 });
+}


### PR DESCRIPTION
Revert #2 and https://github.com/vislyhq/stretch/pull/87
The test from #2 is still present and still successful.

With those two PRs, the value returned for location is the absolute value. Without, the value is relative to its parent.

The test expect the value to be relative, as for example in this test:
https://github.com/DioxusLabs/stretch/blob/02033c0e8f52c9d12c40557804162eadd3f8a3a2/tests/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs#L77-L84
where `node10` has a location.x of 0 even though its parent `node1` has a location.x of 80

This PR makes it work OK for Bevy again