### PR TITLE
Remove badges section in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,6 @@ keywords = ["ios", "android", "cross-platform", "layout", "flexbox"]
 categories = ["gui"]
 license-file = "LICENSE"
 
-[badges]
-circle-ci = { repository = "vislyhq/stretch", branch = "master" }
-maintenance = { status = "experimental" }
-
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }
 hash32 = "0.2.1"


### PR DESCRIPTION
Closes #18.

The `[badges]` section in Cargo.toml included a `circle-ci` badge which is not applicable to this repository. It also included a `maintenance` status, but this is currently not used on crates.io, so I removed it as well ([Docs](https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section)).