### PR TITLE
Add markdownlint to CI action

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,35 @@
+---
+###########################
+###########################
+## Markdown Linter rules ##
+###########################
+###########################
+
+# Linter rules doc:
+# - https://github.com/DavidAnson/markdownlint
+#
+# Note:
+# To comment out a single error:
+#   <!-- markdownlint-disable -->
+#   any violations you want
+#   <!-- markdownlint-restore -->
+#
+
+###############
+# Rules by id #
+###############
+# MD004: false                  # Unordered list style
+# MD007:
+#   indent: 2                   # Unordered list indentation
+# MD013:
+#   line_length: 400            # Line length 80 is far to short
+# MD026:
+#   punctuation: ".,;:!。，；:"  # List of not allowed
+# MD029: false                  # Ordered list item prefix
+# MD033: false                  # Allow inline HTML
+# MD036: false                  # Emphasis used instead of a heading
+
+#################
+# Rules by tags #
+#################
+# blank_lines: false  # Error on blank lines

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,19 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+  
+  markdownlint:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+      - name: Run Markdown Lint
+        uses: docker://ghcr.io/github/super-linter:slim-v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_MARKDOWN: true
+          DEFAULT_BRANCH: master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
   markdownlint:
     name: Markdown Lint
     runs-on: ubuntu-latest
-    if: always()
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Closes #13.

This adds a new step to the CI workflow which runs [markdownlint](https://github.com/DavidAnson/markdownlint).

I copied it [from bevy](https://github.com/bevyengine/bevy/blob/ae580e58dd1d8539e26a44a4d428e1aa45a3d6f9/.github/workflows/ci.yml#L184-L198) for the most part, with some adjustments:
- Added a `name` for consistency with the other CI steps.
- Removed dependency on `check-missing-examples-in-docs`, because we don't have that.
- Replaced the `.markdown-lint.yml` rule template with the one from the [official templates](https://github.com/github/super-linter/blob/main/TEMPLATES/.markdown-lint.yml), so that it links to the rules and provides some examples. I commented out the example rules, although I'm not sure if that was necessary due to the `---` usage at the start of the file?

Open questions:
- Does it actually work? I'm not sure if it requires any additional configuration.
- Does the `if: always()` do anything or can it be removed?