### PR TITLE
Forbid unsafe code

### DIFF
--- a/src/forest.rs
+++ b/src/forest.rs
@@ -157,7 +157,7 @@ impl Forest {
         }
     }
 
-    pub unsafe fn remove_child(&mut self, node: NodeId, child: NodeId) -> NodeId {
+    pub fn remove_child(&mut self, node: NodeId, child: NodeId) -> NodeId {
         let index = self.children[node].iter().position(|n| *n == child).unwrap();
         self.remove_child_at_index(node, index)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![forbid(unsafe_code)]
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;

--- a/src/node.rs
+++ b/src/node.rs
@@ -153,7 +153,7 @@ impl Stretch {
         let node_id = self.find_node(node)?;
         let child_id = self.find_node(child)?;
 
-        let prev_id = unsafe { self.forest.remove_child(node_id, child_id) };
+        let prev_id = self.forest.remove_child(node_id, child_id);
         Ok(self.ids_to_nodes[&prev_id])
     }
 


### PR DESCRIPTION
Closes #21.

This PR adds `#![forbid(unsafe_code)]` on a crate level.

It also removes unnecessary usages of the `unsafe` keyword in the `remove_child` function:
- https://github.com/DioxusLabs/stretch/blob/c267e6296caea4217a498935ccaf57483b5c9235/src/forest.rs#L160-L163
- https://github.com/DioxusLabs/stretch/blob/c267e6296caea4217a498935ccaf57483b5c9235/src/node.rs#L156