### PR TITLE
Add CI jobs for checking and testing with no default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,21 @@ jobs:
         with:
           command: check
 
+  check-no-default-features:
+    name: Check (no default features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features
+
   test:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -30,6 +45,21 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+
+  test-no-default-features:
+    name: Test Suite (no default features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,50 +3,6 @@ on: [push, pull_request]
 name: Continuous integration
 
 jobs:
-  check-features-none:
-    name: "Check [Features: None]"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features
-
-  check-features-default:
-    name: "Check [Features: Default]"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-
-  check-features-alloc:
-    name: "Check [Features: alloc]"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --features alloc
-
   test-features-none:
     name: "Test Suite [Features: None]"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,22 +3,8 @@ on: [push, pull_request]
 name: Continuous integration
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-
-  check-no-default-features:
-    name: Check (no default features)
+  check-features-none:
+    name: "Check [Features: None]"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -32,8 +18,8 @@ jobs:
           command: check
           args: --no-default-features
 
-  test:
-    name: Test Suite
+  check-features-default:
+    name: "Check [Features: Default]"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -44,10 +30,25 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: check
 
-  test-no-default-features:
-    name: Test Suite (no default features)
+  check-features-alloc:
+    name: "Check [Features: alloc]"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features --features alloc
+
+  test-features-none:
+    name: "Test Suite [Features: None]"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -60,6 +61,35 @@ jobs:
         with:
           command: test
           args: --no-default-features
+
+  test-features-default:
+    name: "Test Suite [Features: Default]"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  test-features-alloc:
+    name: "Test Suite [Features: alloc]"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features alloc
 
   fmt:
     name: Rustfmt

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -57,16 +57,14 @@ mod alloc {
 
 #[cfg(all(not(feature = "alloc"), not(feature = "std")))]
 mod core {
-    use typenum::marker_traits::Unsigned;
+    const MAX_NODE_COUNT: usize = 256;
+    const MAX_CHILD_COUNT: usize = 16;
+    const MAX_PARENTS_COUNT: usize = 1;
 
-    type MaxNodeCount = heapless::consts::U256;
-    type MaxChildCount = heapless::consts::U16;
-    type MaxParentsCount = heapless::consts::U1;
-
-    pub type Map<K, V> = ::heapless::FnvIndexMap<K, V, MaxNodeCount>;
-    pub type Vec<A> = ::arrayvec::ArrayVec<[A; MaxNodeCount::USIZE]>;
-    pub type ChildrenVec<A> = ::arrayvec::ArrayVec<[A; MaxChildCount::USIZE]>;
-    pub type ParentsVec<A> = ::arrayvec::ArrayVec<[A; MaxParentsCount::USIZE]>;
+    pub type Map<K, V> = ::heapless::FnvIndexMap<K, V, MAX_NODE_COUNT>;
+    pub type Vec<A> = ::arrayvec::ArrayVec<[A; MAX_NODE_COUNT]>;
+    pub type ChildrenVec<A> = ::arrayvec::ArrayVec<[A; MAX_CHILD_COUNT]>;
+    pub type ParentsVec<A> = ::arrayvec::ArrayVec<[A; MAX_PARENTS_COUNT]>;
 
     pub fn new_map_with_capacity<K, V>(_capacity: usize) -> Map<K, V>
     where

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -62,9 +62,9 @@ mod core {
     const MAX_PARENTS_COUNT: usize = 1;
 
     pub type Map<K, V> = ::heapless::FnvIndexMap<K, V, MAX_NODE_COUNT>;
-    pub type Vec<A> = ::arrayvec::ArrayVec<[A; MAX_NODE_COUNT]>;
-    pub type ChildrenVec<A> = ::arrayvec::ArrayVec<[A; MAX_CHILD_COUNT]>;
-    pub type ParentsVec<A> = ::arrayvec::ArrayVec<[A; MAX_PARENTS_COUNT]>;
+    pub type Vec<A> = ::arrayvec::ArrayVec<A, MAX_NODE_COUNT>;
+    pub type ChildrenVec<A> = ::arrayvec::ArrayVec<A, MAX_CHILD_COUNT>;
+    pub type ParentsVec<A> = ::arrayvec::ArrayVec<A, MAX_PARENTS_COUNT>;
 
     pub fn new_map_with_capacity<K, V>(_capacity: usize) -> Map<K, V>
     where

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -73,10 +73,7 @@ mod core {
         Map::new()
     }
 
-    pub fn new_vec_with_capacity<T, A>(_capacity: usize) -> ::arrayvec::ArrayVec<A>
-    where
-        A: ::arrayvec::Array<Item = T>,
-    {
+    pub fn new_vec_with_capacity<A, const CAP: usize>(_capacity: usize) -> ::arrayvec::ArrayVec<A, CAP> {
         ::arrayvec::ArrayVec::new()
     }
 


### PR DESCRIPTION
Closes #32.

This PR adds two new jobs to the CI workflow to `cargo check` and `cargo test` with the `--no-default-features` flag. Currently this has mainly the effect of enabling `no_std`.

Notably these currently throw errors, which just highlights the need to include it in CI.

I'm not sure if I'm able to resolve these errors as I've never worked with `no_std` before, but I can certainly try :)

Side note: Why do we have both `cargo check` and `cargo test` jobs? Wouldn't `cargo test` always fail if `cargo check` fails?

**TODO**:
- [x] Fix errors from migrating to `heapless@0.7.9`
- [x] Fix errors from migrate to `arrayvec@0.7.2`
- [x] Add CI checks/tests with `--no-default-features --features alloc` flags

⚠️ **This is a breaking change!** (I think) ⚠️

The fixes to the no-default-feature configuration is probably a breaking change.