### PR TITLE
Fix license information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "High performance & cross-platform Flexbox implementation"
 repository = "https://github.com/DioxusLabs/stretch"
 keywords = ["ios", "android", "cross-platform", "layout", "flexbox"]
 categories = ["gui"]
-license-file = "LICENSE.md"
+license = "MIT"
 
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "High performance & cross-platform Flexbox implementation"
 repository = "https://github.com/DioxusLabs/stretch"
 keywords = ["ios", "android", "cross-platform", "layout", "flexbox"]
 categories = ["gui"]
-license-file = "LICENSE"
+license-file = "LICENSE.md"
 
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,10 @@
-MIT License
+# License
 
-Copyright (c) 2018 Visly Inc.
+The copyright of all contributions to this open source software library remains with the original authors, who by contributing grant others a license to freely use, share and modify their work under the MIT license below.
+
+This library was forked from the [`stretch`](https://github.com/vislyhq/stretch) crate under the MIT License, which was copyright 2018 Visly Inc.
+
+## MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +23,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-


### PR DESCRIPTION
# Objective

- The LICENSE incorrectly listed all contributions as belonging to Visly.
- The cargo metadata for the license was misconfigured.
- Fixes #10.

## Solution

- Clarify the state of the license: copyright remains with the open source contributors, who license it under MIT
- Fix the metadata in Cargo.toml