### PR TITLE
Improve PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,29 @@
 # Objective
 
-- Describe the objective or issue this PR addresses.
-- If you're fixing a specific issue, say "Fixes #X".
+Describe the objective or issue this PR addresses.
 
-## Solution
+If you're fixing a specific issue, say "Fixes #X" and the linked issue will automatically be closed when this PR is merged.
+Under each bullet point, describe how this change addressed those objectives if it is not obvious.
 
-- Describe the solution used to achieve the objective above.
+**Changes that will affect external library users must update RELEASES.md before they will be merged.**
 
----
+## Context
 
-## Changelog
+Discuss any context that may be needed for a user with only passing accquaintance with this library to understand the changes you've made.
+This may include related issues, previous discussion, or relevant bits of how the library works).
 
-> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.
+## Feeback wanted
 
-- What changed as a result of this PR?
-- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
-- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
-  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!
+> This section is optional. If there are no particularly tricky or controversial changes, you can delete this section.
+
+Which parts of this PR were you unsure about? Which parts were particularly tricky?
+
+If you're stuck on part of the changes or want feedback early, open a draft PR and list the items that need to be completed here using a checklist.
 
 ## Migration Guide
 
 > This section is optional. If there are no breaking changes, you can delete this section.
 
-- If this PR is a breaking change (relative to the last release of this crate), describe how a user might need to migrate their code to support these changes
+- If this PR is a breaking change (relative to the last release of this library), describe how a user might need to migrate their code to support these changes
 - Simply adding new functionality is not a breaking change.
-- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.
+- Fixing behavior that was definitely a bug, rather than a questionable design choice, is not a breaking change.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,10 +9,10 @@ Under each bullet point, describe how this change addressed those objectives if 
 
 ## Context
 
-Discuss any context that may be needed for a user with only passing accquaintance with this library to understand the changes you've made.
+Discuss any context that may be needed for a user with only passing acquaintance with this library to understand the changes you've made.
 This may include related issues, previous discussion, or relevant bits of how the library works).
 
-## Feeback wanted
+## Feedback wanted
 
 > This section is optional. If there are no particularly tricky or controversial changes, you can delete this section.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ This may include related issues, previous discussion, or relevant bits of how th
 
 Which parts of this PR were you unsure about? Which parts were particularly tricky?
 
-If you're stuck on part of the changes or want feedback early, open a draft PR and list the items that need to be completed here using a checklist.
+If you're stuck on part of the changes or want feedback early, open a draft PR and list the items that need to be completed here using a [checklist](https://github.blog/2014-04-28-task-lists-in-all-markdown-documents/).
 
 ## Migration Guide
 


### PR DESCRIPTION
# Objective

- the existing PR template was repetitive
  - merge Objective and Solution sections
- the existing PR template often caused contributors to open PRs without adequate context
  - add a section on Context, with additional prompts for useful information
- the Changelog section was redundant to RELEASES.md
  - add a strongly worded note reminding authors to update this file
  - remove Changelog section
- the PR template did not make clear that authors should call out the areas that are tricky or controversial in their PR description
   - add a Feedback Wanted section
      
## Context

This template was first added in #30, and was borrowed from Bevy. Many of these observations are based on the patterns observed there.