### PR TITLE
Make PR template clearer and shorter

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,16 @@
 # Objective
 
-Describe the objective or issue this PR addresses.
+Why did you make this PR?
 
-If you're fixing a specific issue, say "Fixes #X" and the linked issue will automatically be closed when this PR is merged.
-Under each bullet point, describe how this change addressed those objectives if it is not obvious.
+If you're fixing a specific issue, say "Fixes #X" and the linked issue will be automatically closed when this PR is merged.
+If it's not obvious, describe how this changes made addressed the objectives.
 
 **Changes that will affect external library users must update RELEASES.md before they will be merged.**
 
 ## Context
 
-Discuss any context that may be needed for a user with only passing acquaintance with this library to understand the changes you've made.
-This may include related issues, previous discussion, or relevant bits of how the library works).
+Discuss any context that may be needed for reviewers to understand the changes you've made.
+This may include related issues, previous discussion, or links to documentation or code.
 
 ## Feedback wanted
 
@@ -24,6 +24,4 @@ If you're stuck on part of the changes or want feedback early, open a draft PR a
 
 > This section is optional. If there are no breaking changes, you can delete this section.
 
-- If this PR is a breaking change (relative to the last release of this library), describe how a user might need to migrate their code to support these changes
-- Simply adding new functionality is not a breaking change.
-- Fixing behavior that was definitely a bug, rather than a questionable design choice, is not a breaking change.
+If this PR is a breaking change (relative to the last release of this library), describe how a user might need to migrate their code to support these changes


### PR DESCRIPTION
# Objective

The PR template was unclear or overly verbose in places

## Context

The changes here were inspired by the helpful feedback in https://github.com/bevyengine/bevy/pull/4815